### PR TITLE
Disable building box2d unit tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ add_git_dependency(
 )
 
 # Add Box2d
+set(BOX2D_BUILD_UNIT_TESTS OFF CACHE BOOL "" FORCE)
 set(BOX2D_BUILD_TESTBED OFF CACHE BOOL "" FORCE)
 add_git_dependency(
     box2d


### PR DESCRIPTION
This PR disables building the Box2d unit tests. These tests fail to build on my Mac (some inline assembly issue, it looks like).