### PR TITLE
updated fmt version in CmakeList

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,7 @@ add_git_dependency(
 add_git_dependency(
     fmt
     https://github.com/fmtlib/fmt.git
-    10.2.1
+    11.1.2
 )
 
 ##########################################################################################


### PR DESCRIPTION
fmt library was giving errors on Emscripten build. It's fixed by updating fmt version.